### PR TITLE
refactor: Change file structure

### DIFF
--- a/components/Resume/Developer/PdfViewer/PdfViewer.tsx
+++ b/components/Resume/Developer/PdfViewer/PdfViewer.tsx
@@ -1,0 +1,3 @@
+export default function PdfViewer() {
+  return <div>pdf viewer</div>;
+}

--- a/components/Resume/Developer/PdfViewer/index.test.tsx
+++ b/components/Resume/Developer/PdfViewer/index.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import PdfViewer from './PdfViewer';
+
+describe('PdfViewer', () => {
+  it('renders pdf viewer', () => {
+    const { getByText } = render(<PdfViewer />);
+
+    expect(getByText('pdf viewer')).toBeInTheDocument();
+  });
+});

--- a/components/Resume/Developer/PdfViewer/index.tsx
+++ b/components/Resume/Developer/PdfViewer/index.tsx
@@ -1,0 +1,3 @@
+import PdfViewer from './PdfViewer';
+
+export default PdfViewer;

--- a/components/Resume/Developer/ResumeControls/ResumeControls.tsx
+++ b/components/Resume/Developer/ResumeControls/ResumeControls.tsx
@@ -1,0 +1,9 @@
+import TitleContainer from '../../containers/TitleContainer';
+
+export default function ResumeControls() {
+  return (
+    <>
+      <TitleContainer />
+    </>
+  );
+}

--- a/components/Resume/Developer/ResumeControls/index.test.tsx
+++ b/components/Resume/Developer/ResumeControls/index.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+
+import ResumeControls from './ResumeControls';
+
+describe('ResumeControls', () => {
+  it("renders '이력서 제목'", () => {
+    const { getByText } = render(<ResumeControls />);
+
+    expect(getByText('이력서 제목')).toBeInTheDocument();
+  });
+});

--- a/components/Resume/Developer/ResumeControls/index.tsx
+++ b/components/Resume/Developer/ResumeControls/index.tsx
@@ -1,0 +1,3 @@
+import ResumeControls from './ResumeControls';
+
+export default ResumeControls;

--- a/components/Resume/components/Title/Title.tsx
+++ b/components/Resume/components/Title/Title.tsx
@@ -37,7 +37,7 @@ type Props = {
   onClick: (element: HTMLDivElement) => void;
 };
 
-export default function ResumeTitle({ onInput, onClick }: Props) {
+export default function Title({ onInput, onClick }: Props) {
   const inputRef = useRef<HTMLDivElement>(null);
 
   function handleInput(event: ChangeEvent<HTMLDivElement>) {

--- a/components/Resume/components/Title/index.test.tsx
+++ b/components/Resume/components/Title/index.test.tsx
@@ -1,14 +1,14 @@
 import { render } from '@testing-library/react';
 
-import ResumeTitle from './ResumeTitle';
+import Title from './Title';
 
-describe('ResumeTitle', () => {
+describe('Title', () => {
   const handleInput = jest.fn();
   const handleClick = jest.fn();
 
   it('renders title', () => {
     const { getByText, container } = render(
-      <ResumeTitle onClick={handleClick} onInput={handleInput} />
+      <Title onClick={handleClick} onInput={handleInput} />
     );
 
     expect(getByText('이력서 제목')).toBeInTheDocument();

--- a/components/Resume/components/Title/index.tsx
+++ b/components/Resume/components/Title/index.tsx
@@ -1,0 +1,3 @@
+import Title from './Title';
+
+export default Title;

--- a/components/Resume/containers/TitleContainer/TitleContainer.tsx
+++ b/components/Resume/containers/TitleContainer/TitleContainer.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 
-import ResumeTitle from '@/components/ResumeTitle';
+import Title from '@/components/Resume/components/Title';
 
-export default function ResumeTitleContainer() {
+export default function TitleContainer() {
   // eslint-disable-next-line no-unused-vars
   const [title, setTitle] = useState<string>('이력서 제목');
 
@@ -15,9 +15,6 @@ export default function ResumeTitleContainer() {
   }
 
   return (
-    <ResumeTitle
-      onInput={handleInputTitle}
-      onClick={handleClickInputControlFocus}
-    />
+    <Title onInput={handleInputTitle} onClick={handleClickInputControlFocus} />
   );
 }

--- a/components/Resume/containers/TitleContainer/index.test.tsx
+++ b/components/Resume/containers/TitleContainer/index.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render } from '@testing-library/react';
 
-import ResumeTitle from './ResumeTitleContainer';
+import TitleContainer from './TitleContainer';
 
-describe('ResumeTitle', () => {
+describe('TitleContainer', () => {
   it('listens change event', () => {
-    const { getByText } = render(<ResumeTitle />);
+    const { getByText } = render(<TitleContainer />);
 
     expect(getByText('이력서 제목')).toBeInTheDocument();
 
@@ -16,7 +16,7 @@ describe('ResumeTitle', () => {
   });
 
   it('listens click event', () => {
-    const { getByText, getByTestId } = render(<ResumeTitle />);
+    const { getByText, getByTestId } = render(<TitleContainer />);
 
     expect(getByText('이력서 제목')).not.toHaveFocus();
 

--- a/components/Resume/containers/TitleContainer/index.tsx
+++ b/components/Resume/containers/TitleContainer/index.tsx
@@ -1,0 +1,3 @@
+import TitleContainer from './TitleContainer';
+
+export default TitleContainer;

--- a/components/ResumeTitle/index.tsx
+++ b/components/ResumeTitle/index.tsx
@@ -1,3 +1,0 @@
-import ResumeTitle from './ResumeTitle';
-
-export default ResumeTitle;

--- a/containers/ResumeTitleContainer/index.tsx
+++ b/containers/ResumeTitleContainer/index.tsx
@@ -1,3 +1,0 @@
-import ResumeTitleContainer from './ResumeTitleContainer';
-
-export default ResumeTitleContainer;

--- a/pages/resume/resume.tsx
+++ b/pages/resume/resume.tsx
@@ -1,9 +1,11 @@
-import ResumeTitleContainer from '@/containers/ResumeTitleContainer';
+import ResumeControls from '@/components/Resume/Developer/ResumeControls';
+import PdfViewer from '@/components/Resume/Developer/PdfViewer';
 
 export default function Resume() {
   return (
     <>
-      <ResumeTitleContainer />
+      <ResumeControls />
+      <PdfViewer />
     </>
   );
 }


### PR DESCRIPTION
폴더 가독성을 위해 파일 구조 개선

나중에 추가 될 직업별 이력서 템플릿을 위해 파일 구조 개선했습니다.
Resume폴더안에 직업별 이력서 템플릿이 들어갈 예정입니다. 현재 Developer만 만들어져있습니다.
또한 직업별 이력서 템플릿에서만 공통으로 사용되는 컴포넌트가 많기때문에 containers/components 폴더를 따로 만들어주었습니다.

<img width="295" alt="스크린샷 2021-08-05 오후 4 17 56" src="https://user-images.githubusercontent.com/77663233/128308211-03007832-25e1-4139-b91e-9eaa44f79740.png">
